### PR TITLE
Add MajorUpgrade element to remove previous installed version

### DIFF
--- a/src/Program.fs
+++ b/src/Program.fs
@@ -153,6 +153,9 @@ let generateMsi() =
                 // Tells the installer to embed all source files
                 Wix.mediaTemplate [ Wix.attr "EmbedCab" "yes" ]
 
+                // Installation of new version will uninstall old version (if found)
+                Wix.majorUpgrade [ Wix.attr "DowngradeErrorMessage" "Can't downgrade." ]
+
                 Wix.directory "TARGETDIR" "SourceDir" [
                     Wix.directoryId "ProgramFilesFolder" [
                         Wix.directory "PULUMIDIR" "Pulumi" []

--- a/src/Wix.fs
+++ b/src/Wix.fs
@@ -105,6 +105,12 @@ let mediaTemplate (elements: obj seq) =
             yield element |> box
     })
 
+let majorUpgrade (elements: obj seq) = 
+    XElement.create(ns + "MajorUpgrade", seq {
+        for element in elements do
+            yield element |> box
+    })
+
 let component' (id: string) (elements: obj seq) = 
     XElement.create(ns + "Component", seq {
         yield XAttribute.create("Id", id) |> box


### PR DESCRIPTION
Current generated Wix is missing [MajorUpgrade](https://wixtoolset.org/documentation/manual/v3/xsd/wix/majorupgrade.html) element.

This causes to have multiple versions installed side by side as also described in #2. Adding this elements schedules removal of previous version. The default setting on this element should be enough.

Default setting of this element forbids downgrades, which I believe is the desired behavior.