### PR TITLE
Fix deploy.yml on repository dispatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
         shell: powershell
         run: |
           $download_exists = Test-Path -Path ./src/download-url.txt -PathType Leaf
-          if (!download_exists) {
+          if (!$download_exists) {
             echo "./src/download-url.txt file was not found, this means we skipped generating an installer"
             return
           }


### PR DESCRIPTION
Missed publishing the last two releases to winget package registry because of this 😓 I've removed the last release from the repository here which means it will trigger the publishing process again when this is merged