### PR TITLE
Updates for WiX Toolset v3.14

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           dotnet-version: '6.0.x'
       - name: Set path for candle and light from WixTools
-        run: echo "C:\Program Files (x86)\WiX Toolset v3.11\bin" >> $GITHUB_PATH
+        run: echo "C:\Program Files (x86)\WiX Toolset v3.14\bin" >> $GITHUB_PATH
         shell: bash
       - name: Generate Pulumi MSI
         run: dotnet run --project ./src -- generate msi

--- a/.github/workflows/generate-msi.yml
+++ b/.github/workflows/generate-msi.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           dotnet-version: '6.0.x'
       - name: Set path for candle and light from WixTools
-        run: echo "C:\Program Files (x86)\WiX Toolset v3.11\bin" >> $GITHUB_PATH
+        run: echo "C:\Program Files (x86)\WiX Toolset v3.14\bin" >> $GITHUB_PATH
         shell: bash
       - name: Generate Pulumi MSI
         run: dotnet run --project ./src -- generate msi


### PR DESCRIPTION
The WiX Toolset was updated from v3.11 to v3.14 in GitHub's `windows-latest` runner image (see [diff](https://github.com/actions/runner-images/commit/3d6eedc86d7bffdcd0a31cad8d8a6677e7f2402e#diff-d3119a278ce9ce80fc4b5af63a1112fb3a044aec3e6002d838e8eb26d7a3a499L90-R91)). Which caused the workflow to fail for the v3.109.0 release.

This PR updates our workflows to use the new version of WiX.

Fixes #23