### PR TITLE
ci: Use .NET 8

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,11 +13,13 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Setup dotnet SDK v6.0
-        uses: actions/setup-dotnet@v1
+        uses: actions/checkout@v4
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: |
+            6.0.x
+            8.0.x
       - name: Set path for candle and light from WixTools
         run: echo "C:\Program Files (x86)\WiX Toolset v3.14\bin" >> $GITHUB_PATH
         shell: bash
@@ -26,10 +28,6 @@ jobs:
           dotnet tool install --global AzureSignTool
       - name: Generate Pulumi MSI
         run: dotnet run --project ./src -- generate msi "${{ secrets.AZURE_KEY_VAULT_URI }}" "${{ secrets.AZURE_CLIENT_ID }}" "${{ secrets.AZURE_TENANT_ID }}" "${{ secrets.AZURE_CLIENT_SECRET }}" "${{ secrets.AZURE_CERT_NAME }}"
-      - name: Setup dotnet SDK v5.0
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '5.0.x'
       - name: Push WinGet Manifest
         shell: powershell
         run: |

--- a/.github/workflows/generate-msi.yml
+++ b/.github/workflows/generate-msi.yml
@@ -13,11 +13,13 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Setup dotnet SDK v6.0
-        uses: actions/setup-dotnet@v1
+        uses: actions/checkout@v4
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: |
+            6.0.x
+            8.0.x
       - name: Set path for candle and light from WixTools
         run: echo "C:\Program Files (x86)\WiX Toolset v3.14\bin" >> $GITHUB_PATH
         shell: bash
@@ -26,10 +28,6 @@ jobs:
           dotnet tool install --global AzureSignTool
       - name: Generate Pulumi MSI
         run: dotnet run --project ./src -- generate msi "${{ secrets.AZURE_KEY_VAULT_URI }}" "${{ secrets.AZURE_CLIENT_ID }}" "${{ secrets.AZURE_TENANT_ID }}" "${{ secrets.AZURE_CLIENT_SECRET }}" "${{ secrets.AZURE_CERT_NAME }}"
-      - name: Setup dotnet SDK v5.0
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '5.0.x'
       - name: Push WinGet Manifest
         shell: powershell
         run: |

--- a/src/Program.fs
+++ b/src/Program.fs
@@ -106,9 +106,10 @@ let clean() =
             File.Delete filePath
 
 let computeSha256 (file: string) = 
-    let sha256Algo = HashAlgorithm.Create("SHA256")
-    let sha256 = sha256Algo.ComputeHash(new MemoryStream(File.ReadAllBytes file))
-    BitConverter.ToString(sha256).Replace("-", "")
+    use fs = File.OpenRead(file)
+    use sha256 = SHA256.Create()
+    let hashBytes = sha256.ComputeHash(fs)
+    Convert.ToHexString(hashBytes)
 
 let generateMsi (keyVaultUri: string) (clientId: string) (tenantId: string) (clientSecret: string) (certName: string) = 
     let latestRelease = await (github.Repository.Release.GetLatest("pulumi", "pulumi"))

--- a/src/PulumiWingetManifest.fsproj
+++ b/src/PulumiWingetManifest.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
AzureSignTool (introduced in #25) requires .NET 8. Install .NET 8 in CI and update the F# program to target .NET 8. As part of this, move off of the deprecated `HashAlgorithm.Create` and cleanup the SHA256 code.

After I made the above changes to the F# program, I realized that `wingetcreate.exe` still [requires .NET 6](https://github.com/microsoft/winget-create?tab=readme-ov-file#using-the-standalone-exe), so we install both .NET 8 and .NET 6 using [`setup-dotnet`](https://github.com/actions/setup-dotnet?tab=readme-ov-file#usage). The F# program improvements are still worth keeping, though.

I've tested the F# program locally in a Windows VM.

Fixes #26