### PR TITLE
Use a shared workflow with org secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ jobs:
   deploy:
     uses: ./.github/workflows/shared.yml
     with:
+      publish_release: true
       push_manifest: true
     secrets:
       AZURE_SIGNING_KEY_VAULT_URI: ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,5 @@
 name: Deploy
 
-env:
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-
 on:
   repository_dispatch:
     types:
@@ -10,35 +7,13 @@ on:
 
 jobs:
   deploy:
-    runs-on: windows-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Setup dotnet
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: |
-            6.0.x
-            8.0.x
-      - name: Set path for candle and light from WixTools
-        run: echo "C:\Program Files (x86)\WiX Toolset v3.14\bin" >> $GITHUB_PATH
-        shell: bash
-      - name: Install AzureSignTool
-        run: |
-          dotnet tool install --global AzureSignTool
-      - name: Generate Pulumi MSI
-        run: dotnet run --project ./src -- generate msi "${{ secrets.AZURE_KEY_VAULT_URI }}" "${{ secrets.AZURE_CLIENT_ID }}" "${{ secrets.AZURE_TENANT_ID }}" "${{ secrets.AZURE_CLIENT_SECRET }}" "${{ secrets.AZURE_CERT_NAME }}"
-      - name: Push WinGet Manifest
-        shell: powershell
-        run: |
-          $download_exists = Test-Path -Path ./src/download-url.txt -PathType Leaf
-          if (!$download_exists) {
-            echo "./src/download-url.txt file was not found, this means we skipped generating an installer"
-            return
-          }
-
-          $github_token = "${{ secrets.PULUMI_BOT_TOKEN }}"
-          $downloadUrl = Get-Content -Path ./src/download-url.txt
-          $version = Get-Content -Path ./src/version.txt
-          iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-          .\wingetcreate.exe update Pulumi.Pulumi --urls $downloadUrl --version $version --token $github_token --submit
+    uses: ./.github/workflows/shared.yml
+    with:
+      push_manifest: true
+    secrets:
+      AZURE_SIGNING_KEY_VAULT_URI: ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI }}
+      AZURE_SIGNING_CLIENT_ID: ${{ secrets.AZURE_SIGNING_CLIENT_ID }}
+      AZURE_SIGNING_TENANT_ID: ${{ secrets.AZURE_SIGNING_TENANT_ID }}
+      AZURE_SIGNING_CLIENT_SECRET: ${{ secrets.AZURE_SIGNING_CLIENT_SECRET }}
+      AZURE_SIGNING_CERT_NAME: ${{ secrets.AZURE_SIGNING_CERT_NAME }}
+      PULUMI_BOT_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}

--- a/.github/workflows/generate-msi.yml
+++ b/.github/workflows/generate-msi.yml
@@ -9,6 +9,7 @@ jobs:
   build:
     uses: ./.github/workflows/shared.yml
     with:
+      publish_release: true
       push_manifest: true
     secrets:
       AZURE_SIGNING_KEY_VAULT_URI: ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,7 @@
-name: Generate MSI
+name: Pull Request
 
 on:
-  push:
+  pull_request:
     branches:
       - master
 
@@ -9,11 +9,10 @@ jobs:
   build:
     uses: ./.github/workflows/shared.yml
     with:
-      push_manifest: true
+      push_manifest: false
     secrets:
       AZURE_SIGNING_KEY_VAULT_URI: ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI }}
       AZURE_SIGNING_CLIENT_ID: ${{ secrets.AZURE_SIGNING_CLIENT_ID }}
       AZURE_SIGNING_TENANT_ID: ${{ secrets.AZURE_SIGNING_TENANT_ID }}
       AZURE_SIGNING_CLIENT_SECRET: ${{ secrets.AZURE_SIGNING_CLIENT_SECRET }}
       AZURE_SIGNING_CERT_NAME: ${{ secrets.AZURE_SIGNING_CERT_NAME }}
-      PULUMI_BOT_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,6 +9,7 @@ jobs:
   build:
     uses: ./.github/workflows/shared.yml
     with:
+      publish_release: false
       push_manifest: false
     secrets:
       AZURE_SIGNING_KEY_VAULT_URI: ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI }}

--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -1,0 +1,64 @@
+name: Shared Workflow
+
+on:
+  workflow_call:
+    inputs:
+      push_manifest:
+        description: 'Whether to push the WinGet manifest'
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      AZURE_SIGNING_KEY_VAULT_URI:
+        required: true
+      AZURE_SIGNING_CLIENT_ID:
+        required: true
+      AZURE_SIGNING_TENANT_ID:
+        required: true
+      AZURE_SIGNING_CLIENT_SECRET:
+        required: true
+      AZURE_SIGNING_CERT_NAME:
+        required: true
+      PULUMI_BOT_TOKEN:
+        required: false
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            6.0.x
+            8.0.x
+
+      - name: Set path for candle and light from WixTools
+        run: echo "C:\Program Files (x86)\WiX Toolset v3.14\bin" >> $GITHUB_PATH
+        shell: bash
+
+      - name: Install AzureSignTool
+        run: |
+          dotnet tool install --global AzureSignTool
+
+      - name: Generate Pulumi MSI
+        run: dotnet run --project ./src -- generate msi "${{ secrets.AZURE_SIGNING_KEY_VAULT_URI }}" "${{ secrets.AZURE_SIGNING_CLIENT_ID }}" "${{ secrets.AZURE_SIGNING_TENANT_ID }}" "${{ secrets.AZURE_SIGNING_CLIENT_SECRET }}" "${{ secrets.AZURE_SIGNING_CERT_NAME }}"
+
+      - name: Push WinGet Manifest
+        if: inputs.push_manifest == true
+        shell: powershell
+        run: |
+          $download_exists = Test-Path -Path ./src/download-url.txt -PathType Leaf
+          if (!$download_exists) {
+            echo "./src/download-url.txt file was not found, this means we skipped generating an installer"
+            return
+          }
+
+          $github_token = "${{ secrets.PULUMI_BOT_TOKEN }}"
+          $downloadUrl = Get-Content -Path ./src/download-url.txt
+          $version = Get-Content -Path ./src/version.txt
+          iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          .\wingetcreate.exe update Pulumi.Pulumi --urls $downloadUrl --version $version --token $github_token --submit

--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Generate Pulumi MSI
         run: dotnet run --project ./src -- ${{ inputs.publish_release && 'generate-publish' || 'generate' }} msi "${{ secrets.AZURE_SIGNING_KEY_VAULT_URI }}" "${{ secrets.AZURE_SIGNING_CLIENT_ID }}" "${{ secrets.AZURE_SIGNING_TENANT_ID }}" "${{ secrets.AZURE_SIGNING_CLIENT_SECRET }}" "${{ secrets.AZURE_SIGNING_CERT_NAME }}"
         env:
-          GITHUB_TOKEN: ${{ inputs.publish_release && secrets.PULUMI_BOT_TOKEN || '' }}
+          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Push WinGet Manifest
         if: inputs.push_manifest == true

--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -3,6 +3,11 @@ name: Shared Workflow
 on:
   workflow_call:
     inputs:
+      publish_release:
+        description: 'Whether to publish the released .MSI'
+        required: false
+        type: boolean
+        default: false
       push_manifest:
         description: 'Whether to push the WinGet manifest'
         required: false
@@ -45,7 +50,9 @@ jobs:
           dotnet tool install --global AzureSignTool
 
       - name: Generate Pulumi MSI
-        run: dotnet run --project ./src -- generate msi "${{ secrets.AZURE_SIGNING_KEY_VAULT_URI }}" "${{ secrets.AZURE_SIGNING_CLIENT_ID }}" "${{ secrets.AZURE_SIGNING_TENANT_ID }}" "${{ secrets.AZURE_SIGNING_CLIENT_SECRET }}" "${{ secrets.AZURE_SIGNING_CERT_NAME }}"
+        run: dotnet run --project ./src -- ${{ inputs.publish_release && 'generate-publish' || 'generate' }} msi "${{ secrets.AZURE_SIGNING_KEY_VAULT_URI }}" "${{ secrets.AZURE_SIGNING_CLIENT_ID }}" "${{ secrets.AZURE_SIGNING_TENANT_ID }}" "${{ secrets.AZURE_SIGNING_CLIENT_SECRET }}" "${{ secrets.AZURE_SIGNING_CERT_NAME }}"
+        env:
+          GITHUB_TOKEN: ${{ inputs.publish_release && secrets.PULUMI_BOT_TOKEN || '' }}
 
       - name: Push WinGet Manifest
         if: inputs.push_manifest == true


### PR DESCRIPTION
This change does two things:

1. Creates a shared workflow file that's called when changes land in `master`, when deploy has been dispatched, and during PRs, so we can actually test out changes in PRs.

2. Switches to the `AZURE_SIGNING_*` org secrets, rather than the secrets in the repo, which are more up-to-date.

Fixes #31