### PR TITLE
Use ESC secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,9 +12,4 @@ jobs:
       publish_release: true
       push_manifest: true
     secrets:
-      AZURE_SIGNING_KEY_VAULT_URI: ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI }}
-      AZURE_SIGNING_CLIENT_ID: ${{ secrets.AZURE_SIGNING_CLIENT_ID }}
-      AZURE_SIGNING_TENANT_ID: ${{ secrets.AZURE_SIGNING_TENANT_ID }}
-      AZURE_SIGNING_CLIENT_SECRET: ${{ secrets.AZURE_SIGNING_CLIENT_SECRET }}
-      AZURE_SIGNING_CERT_NAME: ${{ secrets.AZURE_SIGNING_CERT_NAME }}
       PULUMI_BOT_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}

--- a/.github/workflows/generate-msi.yml
+++ b/.github/workflows/generate-msi.yml
@@ -12,9 +12,4 @@ jobs:
       publish_release: true
       push_manifest: true
     secrets:
-      AZURE_SIGNING_KEY_VAULT_URI: ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI }}
-      AZURE_SIGNING_CLIENT_ID: ${{ secrets.AZURE_SIGNING_CLIENT_ID }}
-      AZURE_SIGNING_TENANT_ID: ${{ secrets.AZURE_SIGNING_TENANT_ID }}
-      AZURE_SIGNING_CLIENT_SECRET: ${{ secrets.AZURE_SIGNING_CLIENT_SECRET }}
-      AZURE_SIGNING_CERT_NAME: ${{ secrets.AZURE_SIGNING_CERT_NAME }}
       PULUMI_BOT_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,9 +11,3 @@ jobs:
     with:
       publish_release: false
       push_manifest: false
-    secrets:
-      AZURE_SIGNING_KEY_VAULT_URI: ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI }}
-      AZURE_SIGNING_CLIENT_ID: ${{ secrets.AZURE_SIGNING_CLIENT_ID }}
-      AZURE_SIGNING_TENANT_ID: ${{ secrets.AZURE_SIGNING_TENANT_ID }}
-      AZURE_SIGNING_CLIENT_SECRET: ${{ secrets.AZURE_SIGNING_CLIENT_SECRET }}
-      AZURE_SIGNING_CERT_NAME: ${{ secrets.AZURE_SIGNING_CERT_NAME }}

--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -1,3 +1,10 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 name: Shared Workflow
 
 on:
@@ -31,6 +38,9 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -50,7 +60,7 @@ jobs:
           dotnet tool install --global AzureSignTool
 
       - name: Generate Pulumi MSI
-        run: dotnet run --project ./src -- ${{ inputs.publish_release && 'generate-publish' || 'generate' }} msi "${{ secrets.AZURE_SIGNING_KEY_VAULT_URI }}" "${{ secrets.AZURE_SIGNING_CLIENT_ID }}" "${{ secrets.AZURE_SIGNING_TENANT_ID }}" "${{ secrets.AZURE_SIGNING_CLIENT_SECRET }}" "${{ secrets.AZURE_SIGNING_CERT_NAME }}"
+        run: dotnet run --project ./src -- ${{ inputs.publish_release && 'generate-publish' || 'generate' }} msi "${{ steps.esc-secrets.outputs.AZURE_SIGNING_KEY_VAULT_URI }}" "${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_ID }}" "${{ steps.esc-secrets.outputs.AZURE_SIGNING_TENANT_ID }}" "${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_SECRET }}" "${{ steps.esc-secrets.outputs.AZURE_SIGNING_CERT_NAME }}"
         env:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -21,16 +21,6 @@ on:
         type: boolean
         default: false
     secrets:
-      AZURE_SIGNING_KEY_VAULT_URI:
-        required: true
-      AZURE_SIGNING_CLIENT_ID:
-        required: true
-      AZURE_SIGNING_TENANT_ID:
-        required: true
-      AZURE_SIGNING_CLIENT_SECRET:
-        required: true
-      AZURE_SIGNING_CERT_NAME:
-        required: true
       PULUMI_BOT_TOKEN:
         required: false
 


### PR DESCRIPTION
These changes migrate this repo's GitHub Actions Workflows to use ESC secrets instead of GitHub Secrets.

The changes are largely mechanical:

- Common configuration for all ESC actions within a workflow is added to the workflow's environment variables
- Permissions are expanded as necessary for workflows that do not grant `id-token: write` permissions
	- `read-all` permissions are replaced with the union of all explicit read permissions and `id-token: write`
	- Default permissions are replaced with `write-all`, which is the equivalent of all explicit write permissions and
	  `id-token: write`
	- Explicit permissions are modified to grant `id-token: write`
- A step that fetches ESC secrets and populates environment variables is added to each step that reads secrets
- Direct references to secrets within the job are replaced with references to the step's outputs

All ESC actions are configured to fetch secrets from a shared ESC environment that contains secrets migrated from GitHub Actions. The ESC action performs its own OIDC exchange to obtain a Pulumi Access Token.
