### PR TITLE
Migrate MSI signing to Azure Trusted Signing

### DIFF
--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -45,12 +45,29 @@ jobs:
         run: echo "C:\Program Files (x86)\WiX Toolset v3.14\bin" >> $GITHUB_PATH
         shell: bash
 
-      - name: Install AzureSignTool
-        run: |
-          dotnet tool install --global AzureSignTool
-
       - name: Generate Pulumi MSI
-        run: dotnet run --project ./src -- ${{ inputs.publish_release && 'generate-publish' || 'generate' }} msi "${{ steps.esc-secrets.outputs.AZURE_SIGNING_KEY_VAULT_URI }}" "${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_ID }}" "${{ steps.esc-secrets.outputs.AZURE_SIGNING_TENANT_ID }}" "${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_SECRET }}" "${{ steps.esc-secrets.outputs.AZURE_SIGNING_CERT_NAME }}"
+        run: dotnet run --project ./src -- generate msi
+        env:
+          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Sign MSI with Azure Trusted Signing
+        uses: azure/artifact-signing-action@v1.2.0
+        with:
+          endpoint: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_ACCOUNT_ENDPOINT }}
+          signing-account-name: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CERT_PROFILE_NAME }}
+          azure-tenant-id: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_TENANT_ID }}
+          azure-client-id: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_ID }}
+          azure-client-secret: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_SECRET }}
+          files-folder: ./src
+          files-folder-filter: msi
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Publish signed MSI to GitHub release
+        if: inputs.publish_release == true
+        run: dotnet run --project ./src -- publish msi
         env:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN || secrets.GITHUB_TOKEN }}
 

--- a/src/Program.fs
+++ b/src/Program.fs
@@ -111,9 +111,9 @@ let computeSha256 (file: string) =
     let hashBytes = sha256.ComputeHash(fs)
     Convert.ToHexString(hashBytes)
 
-let generateMsi (keyVaultUri: string) (clientId: string) (tenantId: string) (clientSecret: string) (certName: string) (publish: bool) = 
+let generateMsi () =
     let latestRelease = await (github.Repository.Release.GetLatest("pulumi", "pulumi"))
-    match findWindowsBinaries latestRelease with 
+    match findWindowsBinaries latestRelease with
     | Error errorMessage -> 
         printfn "Error occured while creating the manifest file for pulumi CLI:"
         printfn "%s" errorMessage
@@ -208,27 +208,38 @@ let generateMsi (keyVaultUri: string) (clientId: string) (tenantId: string) (cli
         Shell.exec("light.exe", $"PulumiInstaller.wixobj -o pulumi-{version latestRelease}-windows-x64.msi")
         let msi = resolvePath [ $"pulumi-{version latestRelease}-windows-x64.msi" ]
 
-        let hasVal (v: string) =
-            not (String.IsNullOrWhiteSpace v)
-
-        if (hasVal keyVaultUri) && (hasVal clientId) && (hasVal tenantId) && (hasVal clientSecret) && (hasVal certName) then
-            printfn "Signing MSI..."
-            Shell.exec("AzureSignTool.exe", $"sign -kvu {keyVaultUri} -kvi {clientId} -kvt {tenantId} -kvs {clientSecret} -kvc {certName} -tr http://timestamp.digicert.com -v {msi}")
-
-        let msiChecksum256 = computeSha256 msi
         let info = FileInfo msi
-        printfn "Succesfully created MSI at '%s' (%d bytes)" msi info.Length
+        printfn "Succesfully created unsigned MSI at '%s' (%d bytes)" msi info.Length
 
-        if publish then
+        // Persist the target version so a subsequent `publish msi` invocation
+        // (after the MSI has been signed by azure/artifact-signing-action) can
+        // locate the artifact without re-querying the Pulumi release.
+        let versionPath = resolvePath [ "version.txt" ]
+        File.WriteAllText(versionPath, version latestRelease)
+        printfn $"Written the release version to file {versionPath}"
+        0
+
+let publishMsi () =
+    let versionPath = resolvePath [ "version.txt" ]
+    if not (File.Exists versionPath) then
+        printfn "Expected version.txt at %s — run `generate msi` before `publish msi`." versionPath
+        1
+    else
+        let targetVersion = (File.ReadAllText versionPath).Trim()
+        let msi = resolvePath [ $"pulumi-{targetVersion}-windows-x64.msi" ]
+        if not (File.Exists msi) then
+            printfn "Expected signed MSI at %s — run `generate msi` and the signing step before `publish msi`." msi
+            1
+        else
             match latestMsiRelease() with
-            | Some msiRelease when version msiRelease = version latestRelease  ->
-                printfn "Version v%s of Pulumi MSI is already published, skipping..." (version msiRelease)
+            | Some msiRelease when version msiRelease = targetVersion ->
+                printfn "Version v%s of Pulumi MSI is already published, skipping..." targetVersion
                 0
-
             | _ ->
                 printfn "Publishing asset to GitHub..."
 
-                let releaseInfo = NewRelease($"v{version latestRelease}")
+                let msiChecksum256 = computeSha256 msi
+                let releaseInfo = NewRelease($"v{targetVersion}")
                 let msiRelease = await (github.Repository.Release.Create("pulumi", "pulumi-winget", releaseInfo))
                 let installerAsset = ReleaseAssetUpload()
                 installerAsset.FileName <- Path.GetFileName msi
@@ -243,35 +254,24 @@ let generateMsi (keyVaultUri: string) (clientId: string) (tenantId: string) (cli
                 let uploadedInstaller = await (github.Repository.Release.UploadAsset(msiRelease, installerAsset))
                 let uploadedChecksumFile = await (github.Repository.Release.UploadAsset(msiRelease, checksumAsset))
 
-                printfn $"Released {version latestRelease}: {uploadedInstaller.BrowserDownloadUrl}"
+                printfn $"Released {targetVersion}: {uploadedInstaller.BrowserDownloadUrl}"
                 printfn $"Checksum: {uploadedChecksumFile.BrowserDownloadUrl}"
 
                 let downloadUrlPath = resolvePath [ "download-url.txt" ]
                 File.WriteAllText(downloadUrlPath, uploadedInstaller.BrowserDownloadUrl)
                 printfn $"Written the release download URL to file {downloadUrlPath}"
-
-                let versionPath = resolvePath [ "version.txt" ]
-                File.WriteAllText(versionPath, version latestRelease)
-                printfn $"Written the release version to file {versionPath}"
                 0
-        else
-            printfn "Skipping publishing asset to GitHub (publish=false)"
-            0
 
 [<EntryPoint>]
 let main (args: string[]) = 
     try
-        match args with 
-        | [| "generate"; "msi" |] -> 
+        match args with
+        | [| "generate"; "msi" |] ->
             clean()
-            generateMsi "" "" "" "" "" false
-        | [| "generate"; "msi"; keyVaultUri; clientId; tenantId; clientSecret; certName |] -> 
-            clean()
-            generateMsi keyVaultUri clientId tenantId clientSecret certName false
-        | [| "generate-publish"; "msi"; keyVaultUri; clientId; tenantId; clientSecret; certName |] -> 
-            clean()
-            generateMsi keyVaultUri clientId tenantId clientSecret certName true
-        | [| "clean" |] ->  
+            generateMsi ()
+        | [| "publish"; "msi" |] ->
+            publishMsi ()
+        | [| "clean" |] ->
             clean()
             0
         | otherwise -> 


### PR DESCRIPTION
## Summary

`AzureSignTool` (Azure Key Vault only) was failing with `800B010A` because the AKV code-signing cert expired (see [run 24158180013](https://github.com/pulumi/pulumi-winget/actions/runs/24158180013/job/70502519775)). Switch MSI signing to [Azure Trusted Signing](https://learn.microsoft.com/en-us/azure/trusted-signing/) via [`azure/artifact-signing-action`](https://github.com/Azure/artifact-signing-action) so certs are Microsoft-managed and can't expire on us.

### Changes

- **`src/Program.fs`**: split the old `generateMsi` into
  - `generate msi` — builds the unsigned MSI and writes `version.txt`; no longer calls `AzureSignTool`.
  - `publish msi` — reads the (now signed) MSI back from disk, computes its checksum, creates a GitHub release and uploads it.
  Removed the Key Vault URI / cert name CLI arguments entirely.
- **`.github/workflows/shared.yml`**: drop the `dotnet tool install --global AzureSignTool` step; run `generate msi`, then `azure/artifact-signing-action@v1.2.0` against `./src/*.msi`, then `publish msi` (only when `publish_release == true`).

This matches the Trusted Signing migration in pulumi/ci-mgmt#2126 so both pipelines consume the same ESC secrets.

### Prerequisites

1. ESC env (`imports/github-secrets`) must expose:
   - `AZURE_SIGNING_ACCOUNT_ENDPOINT` = `https://wus2.codesigning.azure.net/`
   - `AZURE_SIGNING_ACCOUNT_NAME` = `pulumi-code-signing`
   - `AZURE_SIGNING_CERT_PROFILE_NAME` = `pulumi-code-signing`
   - `AZURE_SIGNING_KEY_VAULT_URI` / `AZURE_SIGNING_CERT_NAME` can be retired after this lands.
2. The signing service principal (`AZURE_SIGNING_CLIENT_ID`) must be granted the **Trusted Signing Certificate Profile Signer** role on the `pulumi-code-signing/pulumi-code-signing` profile.

### Test plan

- [ ] ESC prereqs in place
- [ ] Trigger the workflow with `publish_release: false` — verify `generate msi` produces the MSI and `azure/artifact-signing-action` signs it successfully
- [ ] Trigger a real release with `publish_release: true` and confirm the published MSI on the GitHub release has a valid Trusted Signing certificate chain
